### PR TITLE
Added function to reset IStateGroup

### DIFF
--- a/engine/src/BooleanNetwork.cc
+++ b/engine/src/BooleanNetwork.cc
@@ -598,6 +598,10 @@ void IStateGroup::display(Network* network, std::ostream& os)
   }
 }
 
+void IStateGroup::reset() {
+  istate_group_list->clear();
+}
+
 Node::~Node()
 {
   delete logicalInputExpr;

--- a/engine/src/BooleanNetwork.h
+++ b/engine/src/BooleanNetwork.h
@@ -1419,7 +1419,8 @@ public:
   static void checkAndComplete(Network* network);
   static void initStates(Network* network, NetworkState& initial_state);
   static void display(Network* network, std::ostream& os);
-
+  static void reset();
+  
 private:
   std::vector<const Node*>* nodes;
   std::vector<ProbaIState*>* proba_istates;


### PR DESCRIPTION
Everytime a new model is parsed, the IStateGroup is not being cleared and thus is growing. 
As far as I remember, the simulation is working, but the Network::initStates execution duration keep increasing. 

So in my code, everytime I reload the model, I'm calling this function to clear the IStateGroup. 

Maybe the call should be added to the end of the parsing code, or at the beginning of the checkAndComplete function. 