### PR TITLE
Allow multiple simulations, with parameter modifications

### DIFF
--- a/engine/src/BooleanNetwork.cc
+++ b/engine/src/BooleanNetwork.cc
@@ -698,3 +698,15 @@ int setConfigVariables(const std::string& prog, const std::string& runvar)
   runvar_v.push_back(runvar);
   return setConfigVariables(prog, runvar_v);
 }
+
+void SymbolTable::unsetSymbolExpressions() {
+  std::vector<SymbolExpression *>::const_iterator begin = symbolExpressions.begin();
+  std::vector<SymbolExpression *>::const_iterator end = symbolExpressions.end();
+
+  while(begin != end) {
+
+    SymbolExpression * exp = *begin;
+    exp->unset();
+    begin++;
+  }
+}

--- a/engine/src/BooleanNetwork.h
+++ b/engine/src/BooleanNetwork.h
@@ -74,6 +74,7 @@ const std::string LOGICAL_XOR_SYMBOL = " ^ ";
 
 class Expression;
 class NotLogicalExpression;
+class SymbolExpression;
 class NetworkState;
 class Network;
 class Node;
@@ -576,6 +577,8 @@ class SymbolTable {
 
   SymbolTable() : last_symb_idx(0) { }
 
+  std::vector<SymbolExpression *> symbolExpressions;
+
 public:
   static SymbolTable* getInstance() {
     if (instance == NULL) {
@@ -632,6 +635,12 @@ public:
   void checkSymbols() const;
 
   void reset();
+
+  void addSymbolExpression(SymbolExpression * exp) {
+    symbolExpressions.push_back(exp);
+  }
+
+  void unsetSymbolExpressions();
 };
 
 // abstract base class used for expression evaluation
@@ -1021,7 +1030,9 @@ class SymbolExpression : public Expression {
   mutable double value;
 
 public:
-  SymbolExpression(const Symbol* symbol) : symbol(symbol), value_set(false) { }
+  SymbolExpression(const Symbol* symbol) : symbol(symbol), value_set(false) { 
+    SymbolTable::getInstance()->addSymbolExpression(this);
+  }
 
   Expression* clone() const {return new SymbolExpression(symbol);}
 
@@ -1044,6 +1055,8 @@ public:
   bool isConstantExpression() const {return true;}
 
   void generateLogicalExpression(LogicalExprGenContext& genctx) const;
+
+  void unset() { value_set = false; }
 };
 
 class AliasExpression : public Expression {


### PR DESCRIPTION
I found the issue which prevented me to make several simulations, with several sets of parameters, without reloading the model. 
In the SymbolExpression class, there is a value_set boolean which is set to true if the value of the symbol has been loaded from symbol table. Once set, if you modify the symbol table, it wont modify the value inside the SymbolExpression. 

What I did to overcome that is : 
- Added a method in SymbolExpression to set to false the value_set (and thus getting the value from SymbolTable of the first eval call)
- Added a vector of all SymbolExpressions in the SymbolTable class. Each instianciation of a SymbolExpression will add it to this vector
- Added a method in SymbolTable to unset all SymbolExpressions