### PR TITLE
Added Docker and Singularity containers for MaBoSS-server

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -23,6 +23,6 @@ EXPOSE 7778
 EXPOSE 7779
 
 # Running MaBoSS server
-CMD /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server --host 0.0.0.0 --port 7777 \
- & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_128n-server --host 0.0.0.0 --port 7778 \
- & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_256n-server --host 0.0.0.0 --port 7779
+CMD /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server -q --host 0.0.0.0 --port 7777 \
+ & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_128n-server -q --host 0.0.0.0 --port 7778 \
+ & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_256n-server -q --host 0.0.0.0 --port 7779

--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -14,9 +14,15 @@ RUN pip3 install matplotlib pandas seaborn xlsxwriter
 ADD . /opt/MaBoSS-env-2.0
 RUN bash -c "cd /opt/MaBoSS-env-2.0; ./check-requirements.sh"
 RUN bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make install"
+RUN bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make MAXNODES=128 install"
+RUN bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make MAXNODES=256 install"
 
 # Exposing port 7777
 EXPOSE 7777
+EXPOSE 7778
+EXPOSE 7779
 
 # Running MaBoSS server
-CMD /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server --host 0.0.0.0 --port 7777
+CMD /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server --host 0.0.0.0 --port 7777 \
+ & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_128n-server --host 0.0.0.0 --port 7778 \
+ & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_256n-server --host 0.0.0.0 --port 7779

--- a/containers/singularity/Singularity
+++ b/containers/singularity/Singularity
@@ -16,6 +16,6 @@ From: ubuntu:18.04
 
 
 %runscript
-    /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server --host 0.0.0.0 --port 7777 \
-    & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_128n-server --host 0.0.0.0 --port 7778 \
-    & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_256n-server --host 0.0.0.0 --port 7779
+    /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server -q --host 0.0.0.0 --port 7777 \
+    & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_128n-server -q --host 0.0.0.0 --port 7778 \
+    & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_256n-server -q --host 0.0.0.0 --port 7779

--- a/containers/singularity/Singularity
+++ b/containers/singularity/Singularity
@@ -1,0 +1,21 @@
+Bootstrap: docker
+From: ubuntu:18.04
+
+%files
+    . /opt/MaBoSS-env-2.0
+
+%post
+    ls /opt/MaBoSS-env-2.0
+    apt-get -qq update
+    apt-get install -yq git flex bison gcc g++ python python-pip python3 python3-pip python3-tk
+    pip3 install matplotlib pandas seaborn xlsxwriter
+    bash -c "cd /opt/MaBoSS-env-2.0; ./check-requirements.sh"
+    bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make install"
+    bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make MAXNODES=128 install"
+    bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make MAXNODES=256 install"
+
+
+%runscript
+    /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server --host 0.0.0.0 --port 7777 \
+    & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_128n-server --host 0.0.0.0 --port 7778 \
+    & /opt/MaBoSS-env-2.0/engine/pub/MaBoSS_256n-server --host 0.0.0.0 --port 7779

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
 
   maboss-server:
     build:
-      context: ./docker
-      dockerfile: Dockerfile
+      context: ./
+      dockerfile: docker/Dockerfile
 
     image: maboss-server
     container_name: maboss-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+#docker-compose.yml
+version: '3.3'
+services:
+
+  maboss-server:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile
+
+    image: maboss-server
+    container_name: maboss-server
+    ports:
+      - "7777:7777"
+    restart: unless-stopped
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,13 @@ services:
   maboss-server:
     build:
       context: ./
-      dockerfile: docker/Dockerfile
+      dockerfile: containers/docker/Dockerfile
 
     image: maboss-server
     container_name: maboss-server
     ports:
       - "7777:7777"
+      - "7778:7778"
+      - "7779:7779"
     restart: unless-stopped
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:bionic
+
+MAINTAINER Vincent Noel version: 1.0
+
+# Preventing python3-tk from asking timezone
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Installing dependencies
+RUN apt-get -qq update
+RUN apt-get install -yq git flex bison gcc g++ python python-pip python3 python3-pip python3-tk
+RUN pip3 install matplotlib pandas seaborn xlsxwriter
+
+# Installing MaBoSS
+RUN git clone https://github.com/maboss-bkmc/MaBoSS-env-2.0.git /opt/MaBoSS-env-2.0
+RUN bash -c "cd /opt/MaBoSS-env-2.0/; ./check-requirements.sh"
+RUN bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; sed -i 's/-lpthread/-lpthread -ldl/' Makefile.maboss; make install" 
+
+# Exposing port 7777
+EXPOSE 7777
+
+# Running MaBoSS server
+CMD /opt/MaBoSS-env-2.0/engine/pub/MaBoSS-server --host 0.0.0.0 --port 7777

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get install -yq git flex bison gcc g++ python python-pip python3 python3
 RUN pip3 install matplotlib pandas seaborn xlsxwriter
 
 # Installing MaBoSS
-RUN git clone https://github.com/maboss-bkmc/MaBoSS-env-2.0.git /opt/MaBoSS-env-2.0
-RUN bash -c "cd /opt/MaBoSS-env-2.0/; ./check-requirements.sh"
+ADD . /opt/MaBoSS-env-2.0
+RUN bash -c "cd /opt/MaBoSS-env-2.0; ./check-requirements.sh"
 RUN bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make install"
 
 # Exposing port 7777

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN pip3 install matplotlib pandas seaborn xlsxwriter
 # Installing MaBoSS
 RUN git clone https://github.com/maboss-bkmc/MaBoSS-env-2.0.git /opt/MaBoSS-env-2.0
 RUN bash -c "cd /opt/MaBoSS-env-2.0/; ./check-requirements.sh"
-RUN bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; sed -i 's/-lpthread/-lpthread -ldl/' Makefile.maboss; make install" 
+RUN bash -c "cd /opt/MaBoSS-env-2.0/engine/src/; make install"
 
 # Exposing port 7777
 EXPOSE 7777


### PR DESCRIPTION
Created containers ready to run MaBoSS-server. 
Each container contains 3 versions of MaBoSS-server, compiled to run models up to 64, 128 and 256 nodes. Theses three versions are accessible using ports 7777, 7778, 7779, respectively.