### PR TITLE
Selecting the proper source files for MaBoSS-server compilation

### DIFF
--- a/engine/src/Makefile.maboss
+++ b/engine/src/Makefile.maboss
@@ -88,8 +88,8 @@ init:
 %$(INFIX).o: %.cc
 	$(CXX) $(CXXFLAGS) -c $*.cc -o $*$(INFIX).o
 
-%$(INFIX)-server.o: %.cc
-	$(CXX) $(CXXFLAGS) -c $*.cc -o $*$(INFIX)-server.o
+%$(INFIX)-server.o: %-server.cc
+	$(CXX) $(CXXFLAGS) -c $*-server.cc -o $*$(INFIX)-server.o
 
 force-init:
 	@CXX=$(CXX) sh init-config.sh force


### PR DESCRIPTION
The latest makefile change introduced chooses MaBoSS.cc as one of the source files for the server, and the compiler ends up choosing the main from MaBoSS.cc. 
This fix ensure only MaBoSS-server.cc will be selected as a source.