### PR TITLE
Added a rule to publish library in lib/ and include/

### DIFF
--- a/engine/src/Makefile.maboss
+++ b/engine/src/Makefile.maboss
@@ -138,6 +138,12 @@ package:
 
 include depend.mk
 
+install_lib: $(MABOSS_LIB)
+	mkdir -p ../lib
+	cp $(MABOSS_LIB) ../lib
+	mkdir -p ../include/
+	cp *.h ../include/
+	
 #### OBSOLETE
 
 #	g++ -dynamiclib -undefined suppress -flat_namespace -o $(MABOSS_LIB) $+ -lpthread


### PR DESCRIPTION
make install_lib will compile libmaboss.so, copy it in the lib directory, and copy the .h files to the include directory. 
Also work with MAXNODES option.