### PR TITLE
Now ignoring all server children exit signal

### DIFF
--- a/engine/src/Server.cc
+++ b/engine/src/Server.cc
@@ -73,6 +73,9 @@ int Server::manageRequests()
     signal(SIGQUIT, unlink_tempfiles_handler);
     signal(SIGTERM, unlink_tempfiles_handler);
     signal(SIGABRT, unlink_tempfiles_handler);
+
+    signal(SIGCHLD, SIG_IGN);
+    
     time_t t = time(NULL);
     char* now = ctime(&t);
     if (!quiet) {


### PR DESCRIPTION
The children threads created to run jobs by the server are not properly dying, because they expect the parent thread to read their exit signal. With this change, it will just ignore their exit message, letting them die.