### PR TITLE
Adding various functions to be used by Physiboss (or other users of the library)

### DIFF
--- a/engine/src/Cumulator.cc
+++ b/engine/src/Cumulator.cc
@@ -362,6 +362,56 @@ void Cumulator::displayCSV(Network* network, unsigned int refnode_count, std::os
   clusterFactory->displayStationaryDistribution(network, os_statdist, hexfloat);
 }
 
+const std::map<double, STATE_MAP<NetworkState_Impl, double> > Cumulator::getStateDists() const
+{
+  std::map<double, STATE_MAP<NetworkState_Impl, double> > result;
+
+  double ratio = time_tick*sample_count;
+  for (int nn = 0; nn < max_tick_index; ++nn) {
+
+    const CumulMap& mp = get_map(nn);
+    CumulMap::Iterator iter = mp.iterator();
+
+    STATE_MAP<NetworkState_Impl, double> t_result;
+
+    while (iter.hasNext()) {
+      NetworkState_Impl state;
+      TickValue tick_value;
+      iter.next(state, tick_value);
+
+      double proba = tick_value.tm_slice / ratio;      
+      t_result[state] = proba;
+    }
+
+    result[((double) nn)*time_tick] = t_result;
+  } 
+  return result;
+}
+
+const STATE_MAP<NetworkState_Impl, double> Cumulator::getNthStateDist(int nn) const
+{
+  double ratio = time_tick*sample_count;
+
+  const CumulMap& mp = get_map(nn);
+  CumulMap::Iterator iter = mp.iterator();
+
+  STATE_MAP<NetworkState_Impl, double> result;
+
+  while (iter.hasNext()) {
+    NetworkState_Impl state;
+    TickValue tick_value;
+    iter.next(state, tick_value);
+
+    double proba = tick_value.tm_slice / ratio;      
+    result[state] = proba;
+  }
+ 
+  return result;
+}
+ 
+const STATE_MAP<NetworkState_Impl, double> Cumulator::getAsymptoticStateDist() const 
+{ return getNthStateDist(getMaxTickIndex()-1); }
+
 void Cumulator::add(unsigned int where, const CumulMap& add_cumul_map)
 {
   CumulMap& to_cumul_map = get_map(where);

--- a/engine/src/Cumulator.h
+++ b/engine/src/Cumulator.h
@@ -388,6 +388,10 @@ public:
 
   void displayCSV(Network* network, unsigned int refnode_count, std::ostream& os_probtraj = std::cout, std::ostream& os_statdist = std::cout, bool hexfloat = false) const;
 
+  const std::map<double, STATE_MAP<NetworkState_Impl, double> > getStateDists() const;
+  const STATE_MAP<NetworkState_Impl, double> getNthStateDist(int nn) const;
+  const STATE_MAP<NetworkState_Impl, double> getAsymptoticStateDist() const;
+  
   void computeMaxTickIndex();
   void epilogue(Network* network, const NetworkState& reference_state);
   void trajectoryEpilogue();

--- a/engine/src/Cumulator.h
+++ b/engine/src/Cumulator.h
@@ -393,6 +393,8 @@ public:
   const STATE_MAP<NetworkState_Impl, double> getAsymptoticStateDist() const;
   
   void computeMaxTickIndex();
+  int getMaxTickIndex() const { return max_tick_index;} 
+
   void epilogue(Network* network, const NetworkState& reference_state);
   void trajectoryEpilogue();
 

--- a/engine/src/MaBEstEngine.cc
+++ b/engine/src/MaBEstEngine.cc
@@ -73,6 +73,10 @@ MaBEstEngine::MaBEstEngine(Network* network, RunConfig* runconfig) :
 
   tid = NULL;
 
+  if (thread_count > sample_count) {
+    thread_count = sample_count;
+  }
+
   if (thread_count > 1 && !runconfig->getRandomGeneratorFactory()->isThreadSafe()) {
     std::cerr << "Warning: non reentrant random, may not work properly in multi-threaded mode\n";
   }

--- a/engine/src/MaBEstEngine.cc
+++ b/engine/src/MaBEstEngine.cc
@@ -420,6 +420,201 @@ void MaBEstEngine::display(std::ostream& output_probtraj, std::ostream& output_s
   }
 }
 
+const std::map<double, STATE_MAP<NetworkState_Impl, double> > MaBEstEngine::getStateDists() const {
+  return merged_cumulator->getStateDists();
+}
+
+const STATE_MAP<NetworkState_Impl, double> MaBEstEngine::getNthStateDist(int nn) const {
+  return merged_cumulator->getNthStateDist(nn);
+}
+
+const STATE_MAP<NetworkState_Impl, double> MaBEstEngine::getAsymptoticStateDist() const {
+  return merged_cumulator->getAsymptoticStateDist();
+}
+
+const std::map<double, std::map<Node *, double> > MaBEstEngine::getNodesDists() const {
+
+  std::map<double, std::map<Node *, double> > result;
+
+  const std::map<double, STATE_MAP<NetworkState_Impl, double> > state_dist = merged_cumulator->getStateDists();
+
+  std::map<double, STATE_MAP<NetworkState_Impl, double> >::const_iterator begin = state_dist.begin();
+  std::map<double, STATE_MAP<NetworkState_Impl, double> >::const_iterator end = state_dist.end();
+  
+  const std::vector<Node*>& nodes = network->getNodes();
+
+  while(begin != end) {
+
+    std::map<Node *, double> node_dist;
+    STATE_MAP<NetworkState_Impl, double> present_state_dist = begin->second;
+
+    std::vector<Node *>::const_iterator nodes_begin = nodes.begin();
+    std::vector<Node *>::const_iterator nodes_end = nodes.end();
+
+    while(nodes_begin != nodes_end) {
+
+      double dist = 0;
+
+      STATE_MAP<NetworkState_Impl, double>::const_iterator states_begin = present_state_dist.begin();
+      STATE_MAP<NetworkState_Impl, double>::const_iterator states_end = present_state_dist.end();
+    
+      while(states_begin != states_end) {
+
+        NetworkState state = states_begin->first;
+        dist += states_begin->second * ((double) state.getNodeState(*nodes_begin));
+
+        states_begin++;
+      }
+
+      node_dist[*nodes_begin] = dist;
+
+      nodes_begin++;
+    }
+
+    result[begin->first] = node_dist;
+
+    begin++;
+  }
+
+  return result;
+}
+
+const std::map<Node*, double> MaBEstEngine::getNthNodesDist(int nn) const {
+  std::map<Node *, double> result;
+
+  const STATE_MAP<NetworkState_Impl, double> state_dist = merged_cumulator->getNthStateDist(nn);
+  
+  const std::vector<Node*>& nodes = network->getNodes();
+  std::vector<Node *>::const_iterator nodes_begin = nodes.begin();
+  std::vector<Node *>::const_iterator nodes_end = nodes.end();
+
+  while(nodes_begin != nodes_end) {
+
+    double dist = 0;
+
+    STATE_MAP<NetworkState_Impl, double>::const_iterator states_begin = state_dist.begin();
+    STATE_MAP<NetworkState_Impl, double>::const_iterator states_end = state_dist.end();
+  
+    while(states_begin != states_end) {
+
+      NetworkState state = states_begin->first;
+      dist += states_begin->second * ((double) state.getNodeState(*nodes_begin));
+
+      states_begin++;
+    }
+
+    result[*nodes_begin] = dist;
+
+    nodes_begin++;
+  }
+
+  return result;  
+}
+
+const std::map<Node*, double> MaBEstEngine::getAsymptoticNodesDist() const {
+  std::map<Node *, double> result;
+
+  const STATE_MAP<NetworkState_Impl, double> state_dist = merged_cumulator->getAsymptoticStateDist();
+  
+  const std::vector<Node*>& nodes = network->getNodes();
+  std::vector<Node *>::const_iterator nodes_begin = nodes.begin();
+  std::vector<Node *>::const_iterator nodes_end = nodes.end();
+
+  while(nodes_begin != nodes_end) {
+
+    double dist = 0;
+
+    STATE_MAP<NetworkState_Impl, double>::const_iterator states_begin = state_dist.begin();
+    STATE_MAP<NetworkState_Impl, double>::const_iterator states_end = state_dist.end();
+  
+    while(states_begin != states_end) {
+
+      NetworkState state = states_begin->first;
+      dist += states_begin->second * ((double) state.getNodeState(*nodes_begin));
+
+      states_begin++;
+    }
+
+    result[*nodes_begin] = dist;
+
+    nodes_begin++;
+  }
+
+  return result;  
+}
+
+const std::map<double, double> MaBEstEngine::getNodeDists(Node * node) const {
+ 
+  std::map<double, double> result;
+
+  const std::map<double, STATE_MAP<NetworkState_Impl, double> > state_dist = merged_cumulator->getStateDists();
+
+  std::map<double, STATE_MAP<NetworkState_Impl, double> >::const_iterator begin = state_dist.begin();
+  std::map<double, STATE_MAP<NetworkState_Impl, double> >::const_iterator end = state_dist.end();
+
+  while(begin != end) {
+
+    STATE_MAP<NetworkState_Impl, double> present_state_dist = begin->second;
+    double dist = 0;
+
+    STATE_MAP<NetworkState_Impl, double>::const_iterator states_begin = present_state_dist.begin();
+    STATE_MAP<NetworkState_Impl, double>::const_iterator states_end = present_state_dist.end();
+  
+    while(states_begin != states_end) {
+
+      NetworkState state = states_begin->first;
+      dist += states_begin->second * ((double) state.getNodeState(node));
+
+      states_begin++;
+    }
+    result[begin->first] = dist;
+
+    begin++;
+  }
+
+  return result; 
+}
+
+double MaBEstEngine::getNthNodeDist(Node * node, int nn) const {
+
+  double result = 0;
+
+  const STATE_MAP<NetworkState_Impl, double> state_dist = merged_cumulator->getNthStateDist(nn);
+  
+  STATE_MAP<NetworkState_Impl, double>::const_iterator states_begin = state_dist.begin();
+  STATE_MAP<NetworkState_Impl, double>::const_iterator states_end = state_dist.end();
+
+  while(states_begin != states_end) {
+
+    NetworkState state = states_begin->first;
+    result += states_begin->second * ((double) state.getNodeState(node));
+
+    states_begin++;
+  }
+
+  return result;  
+}
+
+double MaBEstEngine::getAsymptoticNodeDist(Node * node) const {
+
+  double result = 0;
+
+  const STATE_MAP<NetworkState_Impl, double> state_dist = merged_cumulator->getAsymptoticStateDist();
+  
+  STATE_MAP<NetworkState_Impl, double>::const_iterator states_begin = state_dist.begin();
+  STATE_MAP<NetworkState_Impl, double>::const_iterator states_end = state_dist.end();
+
+  while(states_begin != states_end) {
+
+    NetworkState state = states_begin->first;
+    result += states_begin->second * ((double) state.getNodeState(node));
+
+    states_begin++;
+  }
+
+  return result;  
+}
+
 MaBEstEngine::~MaBEstEngine()
 {
   for (std::vector<Cumulator*>::iterator iter = cumulator_v.begin(); iter < cumulator_v.end(); ++iter) {

--- a/engine/src/MaBEstEngine.h
+++ b/engine/src/MaBEstEngine.h
@@ -87,6 +87,20 @@ public:
 
   void display(std::ostream& output_probtraj, std::ostream& output_statdist, std::ostream& output_fp, bool hexfloat = false) const;
 
+  const std::map<double, STATE_MAP<NetworkState_Impl, double> > getStateDists() const;
+  const STATE_MAP<NetworkState_Impl, double> getNthStateDist(int nn) const;
+  const STATE_MAP<NetworkState_Impl, double> getAsymptoticStateDist() const;
+
+  const std::map<double, std::map<Node *, double> > getNodesDists() const;
+  const std::map<Node*, double> getNthNodesDist(int nn) const;
+  const std::map<Node*, double> getAsymptoticNodesDist() const;
+
+  const std::map<double, double> getNodeDists(Node * node) const;
+  double getNthNodeDist(Node * node, int nn) const;
+  double getAsymptoticNodeDist(Node * node) const;
+  
+  int getMaxTickIndex() const {return merged_cumulator->getMaxTickIndex();} 
+
   long long getElapsedCoreRunTime() const {return elapsed_core_runtime;}
   long long getUserCoreRunTime() const {return user_core_runtime;}
 

--- a/engine/src/Makefile.maboss
+++ b/engine/src/Makefile.maboss
@@ -21,8 +21,9 @@ MABOSS := MaBoSS$(INFIX)
 MABOSS_SERVER := MaBoSS$(INFIX)-server
 MABOSS_CLIENT := MaBoSS-client
 
-MABOSS_LIBNAME = maboss$(INFIX)
+MABOSS_LIBNAME = MaBoSS$(INFIX)
 MABOSS_LIB = lib$(MABOSS_LIBNAME).so
+MABOSS_ALIB = lib$(MABOSS_LIBNAME).a
 
 ifeq ($(shell grep @HAS_UNORDERED_MAP maboss-config.h > /dev/null 2> /dev/null && echo OK), OK)
 EXTRA_FLAGS = -std=c++0x
@@ -53,6 +54,9 @@ MABOSS_OBJS = $(LIB_OBJS)
 endif
 
 all: $(MABOSS_LIB) $(MABOSS) $(MABOSS_SERVER) $(MABOSS_CLIENT)
+
+$(MABOSS_ALIB): $(LIB_OBJS)
+	ar rcs $(MABOSS_ALIB) $+
 
 $(MABOSS_LIB): $(LIB_OBJS)
 	g++ -shared -o $(MABOSS_LIB) $+ -lpthread -ldl
@@ -143,7 +147,13 @@ install_lib: $(MABOSS_LIB)
 	cp $(MABOSS_LIB) ../lib
 	mkdir -p ../include/
 	cp *.h ../include/
-	
+
+install_alib: $(MABOSS_ALIB)
+	mkdir -p ../lib
+	cp $(MABOSS_ALIB) ../lib
+	mkdir -p ../include/
+	cp *.h ../include/
+
 #### OBSOLETE
 
 #	g++ -dynamiclib -undefined suppress -flat_namespace -o $(MABOSS_LIB) $+ -lpthread

--- a/engine/src/RunConfig.h
+++ b/engine/src/RunConfig.h
@@ -73,6 +73,7 @@ class RunConfig {
   unsigned int getSampleCount() const {return sample_count;}
   bool isDiscreteTime() const {return discrete_time;}
   int getSeedPseudoRandom() const {return seed_pseudorand;}
+  void setSeedPseudoRandom(int seed) { seed_pseudorand = seed;}
   void display(Network* network, time_t start_time, time_t end_time, MaBEstEngine& mabest, std::ostream& os) const;
   bool displayTrajectories() const {return display_traj;}
   unsigned int getThreadCount() const {return thread_count;}


### PR DESCRIPTION
A static function to set the pseudorandom seed : 
- void RunConfig::setSeedPseudoRandom(int seed)

Functions to access results of a Cumulator :   
- const std::map<double, STATE_MAP<NetworkState_Impl, double> > getStateDists() const
- const STATE_MAP<NetworkState_Impl, double> getNthStateDist(int nn) const
- const STATE_MAP<NetworkState_Impl, double> getAsymptoticStateDist() const
- int getMaxTickIndex() const 

Functions to access results (states and nodes) of the merged cumulator in MaBEstEngine : 
- const std::map<double, STATE_MAP<NetworkState_Impl, double> > getStateDists() const
- const STATE_MAP<NetworkState_Impl, double> getNthStateDist(int nn) const
- const STATE_MAP<NetworkState_Impl, double> getAsymptoticStateDist() const

- const std::map<double, std::map<Node *, double> > getNodesDists() const
- const std::map<Node*, double> getNthNodesDist(int nn) const
- const std::map<Node*, double> getAsymptoticNodesDist() const

- const std::map<double, double> getNodeDists(Node * node) const
- double getNthNodeDist(Node * node, int nn) const
- double getAsymptoticNodeDist(Node * node) const

- int getMaxTickIndex() const 

Static functions to set initial values of the network : 
- void setInitialState(Network * network, NetworkState * state)
- void setNodeProba(Network * network, Node * node, double value)

One bugfix : Limit thread_count to the value of sample_count. If there are less samples to simulate than the number of threads, then we just need sample_count threads. 