### PR TITLE
Makefile default behavior is now to compile MaBoSS (only)

### DIFF
--- a/engine/src/Makefile
+++ b/engine/src/Makefile
@@ -8,7 +8,7 @@
 
 MAKEFILE = Makefile.maboss
 
-all:
+maboss:
 %:
 	@rm -f depend.mk
 	@touch depend.mk

--- a/engine/src/Makefile.maboss
+++ b/engine/src/Makefile.maboss
@@ -53,6 +53,8 @@ else
 MABOSS_OBJS = $(LIB_OBJS)
 endif
 
+maboss: $(MABOSS)
+
 all: $(MABOSS_LIB) $(MABOSS) $(MABOSS_SERVER) $(MABOSS_CLIENT)
 
 $(MABOSS_ALIB): $(LIB_OBJS)


### PR DESCRIPTION
the default "make" command used to be equivalent to "make all", building MaBoSS, MaBoSS-Server, MaBoSS-Client, and libMaBoSS. 

The new behavior will now be to just compile MaBoSS.
This is motivated by the fact that MaBoSS-Client and MaBoSS-Server are using BSD sockets library, which is not compatible with Windows (we would need to adapt it to winsock, which could be done). 

So with this fix, the default "make" will work on windows, while "make all" will work only on Unix OSs. 

