### PR TITLE
Fixing variables as user func parameters

### DIFF
--- a/engine/src/BooleanNetwork.h
+++ b/engine/src/BooleanNetwork.h
@@ -1319,7 +1319,7 @@ class FuncCallExpression : public Expression {
   std::string funname;
   ArgumentList* arg_list;
   Function* function;
-  bool is_const;
+  bool is_const = false;
   double value;
 
 public:
@@ -1330,12 +1330,14 @@ public:
       throw BNException("unknown function " + funname);
     }
     function->check(arg_list);
-
-    is_const = function->isDeterministic() && isConstantExpression();
-    if (is_const) {
-      NetworkState network_state;
-      value = function->eval(NULL, network_state, arg_list);
-    }
+    
+    // This part is evaluating the formula, but if there is a parameter its value
+    // has not been parsed yet. So this will fail. 
+    // is_const = function->isDeterministic() && isConstantExpression();
+    // if (is_const) {
+    //   NetworkState network_state;
+    //   value = function->eval(NULL, network_state, arg_list);
+    // }
  }
 
   Expression* clone() const {return new FuncCallExpression(funname, arg_list->clone());}


### PR DESCRIPTION
When parsing the bnd file, if there is a user defined formula, MaBoSS will try to check if its constant, and if so, compute its value. 
However, if there is a parameter or variable as a function argument, it won't be able to get the value as its defined in the cfg file. 

The ideal would be to perform this step after the last cfg file has been loaded. 
But for now, we just remove this pre-computation. 