### PR TITLE
Added a new result file for asymptotic state probabilities

### DIFF
--- a/engine/src/Cumulator.cc
+++ b/engine/src/Cumulator.cc
@@ -362,6 +362,82 @@ void Cumulator::displayCSV(Network* network, unsigned int refnode_count, std::os
   clusterFactory->displayStationaryDistribution(network, os_statdist, hexfloat);
 }
 
+void Cumulator::displayAsymptoticCSV(Network *network, unsigned int refnode_count, std::ostream &os_asymptprob, bool hexfloat, bool proba) const
+{
+
+  std::vector<Node *>::const_iterator begin_network;
+
+  os_asymptprob << "Time";
+
+  double ratio;
+  if (proba)
+  {
+    ratio = time_tick * sample_count;
+  }
+  else
+  {
+    ratio = time_tick;
+  }
+
+  // Choosing the last tick
+  int nn = max_tick_index - 1;
+
+#ifdef HAS_STD_HEXFLOAT
+  if (hexfloat)
+  {
+    os_asymptprob << std::hexfloat;
+  }
+#endif
+  // TH
+  const CumulMap &mp = get_map(nn);
+  CumulMap::Iterator iter = mp.iterator();
+
+
+    while (iter.hasNext())
+  {
+    NetworkState_Impl state;
+    TickValue tick_value;
+    iter.next(state, tick_value);
+
+    os_asymptprob << '\t';
+    NetworkState network_state(state);
+    network_state.displayOneLine(os_asymptprob, network);
+  }
+
+  os_asymptprob << '\n';
+  iter.rewind();
+  os_asymptprob << std::setprecision(4) << std::fixed << (nn * time_tick);
+
+  
+  std::string zero_hexfloat = fmthexdouble(0.0);
+  
+  // Proba, ErrorProba
+  while (iter.hasNext())
+  {
+    NetworkState_Impl state;
+    TickValue tick_value;
+    iter.next(state, tick_value);
+    double proba = tick_value.tm_slice / ratio;
+    if (proba)
+    {
+      if (hexfloat)
+      {
+        os_asymptprob << '\t' << std::setprecision(6) << fmthexdouble(proba);
+      }
+      else
+      {
+        os_asymptprob << '\t' << std::setprecision(6) << proba;
+      }
+    }
+    else
+    {
+      int t_proba = static_cast<int>(round(proba));
+      os_asymptprob << '\t' << std::fixed << t_proba;
+    }
+  }
+  os_asymptprob << '\n';
+}
+
 const std::map<double, STATE_MAP<NetworkState_Impl, double> > Cumulator::getStateDists() const
 {
   std::map<double, STATE_MAP<NetworkState_Impl, double> > result;

--- a/engine/src/Cumulator.h
+++ b/engine/src/Cumulator.h
@@ -387,6 +387,7 @@ public:
   }
 
   void displayCSV(Network* network, unsigned int refnode_count, std::ostream& os_probtraj = std::cout, std::ostream& os_statdist = std::cout, bool hexfloat = false) const;
+  void displayAsymptoticCSV(Network* network, unsigned int refnode_count, std::ostream& os_asymptprob = std::cout, bool hexfloat = false, bool proba = true) const;
 
   const std::map<double, STATE_MAP<NetworkState_Impl, double> > getStateDists() const;
   const STATE_MAP<NetworkState_Impl, double> getNthStateDist(int nn) const;

--- a/engine/src/MaBEstEngine.cc
+++ b/engine/src/MaBEstEngine.cc
@@ -424,6 +424,11 @@ void MaBEstEngine::display(std::ostream& output_probtraj, std::ostream& output_s
   }
 }
 
+void MaBEstEngine::displayAsymptotic(std::ostream& output_asymptprob, bool hexfloat, bool proba) const
+{
+  merged_cumulator->displayAsymptoticCSV(network, refnode_count, output_asymptprob, hexfloat, proba);
+}
+
 const std::map<double, STATE_MAP<NetworkState_Impl, double> > MaBEstEngine::getStateDists() const {
   return merged_cumulator->getStateDists();
 }

--- a/engine/src/MaBEstEngine.h
+++ b/engine/src/MaBEstEngine.h
@@ -86,6 +86,7 @@ public:
   bool converges() const {return fixpoints.size() > 0;}
 
   void display(std::ostream& output_probtraj, std::ostream& output_statdist, std::ostream& output_fp, bool hexfloat = false) const;
+  void displayAsymptotic(std::ostream& output_asymptprob, bool hexfloat = false, bool proba = true) const;
 
   const std::map<double, STATE_MAP<NetworkState_Impl, double> > getStateDists() const;
   const STATE_MAP<NetworkState_Impl, double> getNthStateDist(int nn) const;


### PR DESCRIPTION
Added an option --export-asymptotic to get a new result file, with only the asymptotic state probabilities (the last time point). 
This new result file also allows, with the --counts option, to export the raw number of trajectories instead of the probability. 