### PR TITLE
Update conda recipe, version bump to 2.2.2

### DIFF
--- a/conda/maboss/meta.yaml
+++ b/conda/maboss/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: maboss
-  version: "2.2.0"
+  version: "2.2.2"
 
 source:
   git_url: https://github.com/maboss-bkmc/MaBoSS-env-2.0.git

--- a/conda/maboss/meta.yaml
+++ b/conda/maboss/meta.yaml
@@ -10,13 +10,10 @@ build:
 
 requirements:
   build:
-    - gcc
+    - {{ compiler('cxx') }}
     - flex
     - bison
     - make
-  run:
-    - libgcc-ng
-    - libstdcxx-ng
 
 about:
   home:  https://maboss.curie.fr

--- a/engine/src/MaBEstEngine.cc
+++ b/engine/src/MaBEstEngine.cc
@@ -38,7 +38,7 @@
 #include <dlfcn.h>
 #include <iostream>
 
-const std::string MaBEstEngine::VERSION = "2.2.0";
+const std::string MaBEstEngine::VERSION = "2.2.2";
 size_t RandomGenerator::generated_number_count = 0;
 static const char* MABOSS_USER_FUNC_INIT = "maboss_user_func_init";
 


### PR DESCRIPTION
Now using the {{ compiler('c') }} template in the conda recipe.